### PR TITLE
336 validate appsetting for client

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,7 @@
 name: Run Test Suite on PR or push to main
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
   pull_request:

--- a/nvssclient/ConfigurationClasses.cs
+++ b/nvssclient/ConfigurationClasses.cs
@@ -1,0 +1,176 @@
+﻿namespace NVSSClient
+{// ConfigurationClasses.cs
+
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel.DataAnnotations;
+    using System.Linq; // For .Select() used in IValidatableObject
+
+    public class AppConfig : IValidatableObject // Top-level config, needs to validate its complex properties
+    {
+        [Required(ErrorMessage = "The 'Kestrel' section is required.")]
+        public KestrelSettings Kestrel { get; set; }
+
+        [Required(ErrorMessage = "The 'ConnectionStrings' section is required.")]
+        public ConnectionStringsSettings ConnectionStrings { get; set; }
+
+        [Required(ErrorMessage = "The 'Authentication' section is required.")]
+        public AuthenticationSettings Authentication { get; set; }
+
+        [Required(ErrorMessage = "The 'JurisdictionEndpoint' is required.")]
+        [Url(ErrorMessage = "The 'JurisdictionEndpoint' must be a valid URL.")]
+        public string JurisdictionEndpoint { get; set; }
+
+        [Required(ErrorMessage = "The 'LocalTesting' setting is required.")]
+        public bool LocalTesting { get; set; }
+
+        [Required(ErrorMessage = "The 'ResendInterval' setting is required.")]
+        [Range(1, int.MaxValue, ErrorMessage = "The 'ResendInterval' must be a positive integer.")]
+        public int ResendInterval { get; set; }
+
+        [Required(ErrorMessage = "The 'PollingInterval' setting is required.")]
+        [Range(1, int.MaxValue, ErrorMessage = "The 'PollingInterval' must be a positive integer.")]
+        public int PollingInterval { get; set; }
+
+        // Implement IValidatableObject to manually trigger validation for nested complex objects
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            // Validate KestrelSettings
+            if (Kestrel != null)
+            {
+                var results = new List<ValidationResult>();
+                var context = new ValidationContext(Kestrel, serviceProvider: null, items: null);
+                if (!Validator.TryValidateObject(Kestrel, context, results, validateAllProperties: true))
+                {
+                    foreach (var result in results)
+                    {
+                        yield return new ValidationResult(result.ErrorMessage, result.MemberNames.Select(name => $"{nameof(Kestrel)}.{name}"));
+                    }
+                }
+            }
+
+            // Validate ConnectionStringsSettings
+            if (ConnectionStrings != null)
+            {
+                var results = new List<ValidationResult>();
+                var context = new ValidationContext(ConnectionStrings, serviceProvider: null, items: null);
+                if (!Validator.TryValidateObject(ConnectionStrings, context, results, validateAllProperties: true))
+                {
+                    foreach (var result in results)
+                    {                       //
+                       yield return new ValidationResult(result.ErrorMessage, result.MemberNames.Select(name => $"{nameof(ConnectionStrings)}.{name}"));
+                    }
+             
+                }
+            }
+
+            // Validate AuthenticationSettings
+            if (Authentication != null)
+            {
+                var results = new List<ValidationResult>();
+                var context = new ValidationContext(Authentication, serviceProvider: null, items: null);
+                if (!Validator.TryValidateObject(Authentication, context, results, validateAllProperties: true))
+                {
+                    foreach (var result in results)
+                    {
+                        yield return new ValidationResult(result.ErrorMessage, result.MemberNames.Select(name => $"{nameof(Authentication)}.{name}"));
+                    }
+                }
+            }
+            // No need to validate JurisdictionEndpoint, LocalTesting, ResendInterval, PollingInterval here,
+            // as their attributes are directly applied to properties of AppConfig and handled by ValidateDataAnnotations.
+        }
+    }
+
+    public class KestrelSettings : IValidatableObject
+    {
+        [Required(ErrorMessage = "The 'Kestrel:EndPoints' section is required.")]
+        public EndPointsSettings EndPoints { get; set; }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            // Validate EndPointsSettings
+            if (EndPoints != null)
+            {
+                var results = new List<ValidationResult>();
+                var context = new ValidationContext(EndPoints, serviceProvider: null, items: null);
+                if (!Validator.TryValidateObject(EndPoints, context, results, validateAllProperties: true))
+                {
+                    foreach (var result in results)
+                    {
+                        // Prepend EndPoints. to the member names for clear error messages
+                        yield return new ValidationResult(result.ErrorMessage, result.MemberNames.Select(name => $"{nameof(EndPoints)}.{name}"));
+                    }
+                }
+            }
+        }
+    }
+
+    public class EndPointsSettings : IValidatableObject
+    {
+        [Required(ErrorMessage = "The 'Kestrel:EndPoints:Http' section is required.")]
+        public HttpSettings Http { get; set; }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            // Validate HttpSettings
+            if (Http != null)
+            {
+                var results = new List<ValidationResult>();
+                var context = new ValidationContext(Http, serviceProvider: null, items: null);
+                if (!Validator.TryValidateObject(Http, context, results, validateAllProperties: true))
+                {
+                    foreach (var result in results)
+                    {
+                        // Prepend Http. to the member names
+                        yield return new ValidationResult(result.ErrorMessage, result.MemberNames.Select(name => $"{nameof(Http)}.{name}"));
+                    }
+                }
+            }
+        }
+    }
+
+    public class HttpSettings
+    {
+        [Required(ErrorMessage = "The 'Kestrel:EndPoints:Http:Url' is required.")]
+        [Url(ErrorMessage = "The 'Kestrel:EndPoints:Http:Url' must be a valid URL.")]
+        public string Url { get; set; }
+    }
+
+    public class AuthenticationSettings
+    {
+        [Required(ErrorMessage = "The 'Authentication:ClientId' is required.")]
+        public string ClientId { get; set; }
+
+        [Required(ErrorMessage = "The 'Authentication:ClientSecret' is required.")]
+        public string ClientSecret { get; set; }
+
+        [Required(ErrorMessage = "The 'Authentication:Username' is required.")]
+        public string Username { get; set; }
+
+        [Required(ErrorMessage = "The 'Authentication:Password' is required.")]
+        public string Password { get; set; }
+
+        [Required(ErrorMessage = "The 'Authentication:Scope' is required.")]
+        public string Scope { get; set; }
+    }
+
+    public class ConnectionStringsSettings
+    {
+        [Required(ErrorMessage = "The 'ConnectionStrings:ClientDatabase' is required.")]
+        public string ClientDatabase { get; set; }
+
+        [Required(ErrorMessage = "The 'ConnectionStrings:AuthServer' is required.")]
+        [Url(ErrorMessage = "The 'ConnectionStrings:AuthServer' must be a valid URL.")]
+        public string AuthServer { get; set; }
+
+        [Required(ErrorMessage = "The 'ConnectionStrings:ApiServer' is required.")]
+        [Url(ErrorMessage = "The 'ConnectionStrings:ApiServer' must be a valid URL.")]
+        public string ApiServer { get; set; }
+
+        [Required(ErrorMessage = "The 'ConnectionStrings:LocalServer' is required.")]
+        [Url(ErrorMessage = "The 'ConnectionStrings:LocalServer' must be a valid URL.")]
+        public string LocalServer { get; set; }
+    }
+
+}

--- a/nvssclient/Startup.cs
+++ b/nvssclient/Startup.cs
@@ -1,11 +1,14 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
-using Microsoft.EntityFrameworkCore;
 using NVSSClient.Models;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 namespace NVSSClient
 {
@@ -15,6 +18,7 @@ namespace NVSSClient
         {
             Configuration = configuration;
             StaticConfig = configuration;
+  //          ValidateKestrelSettings();
         }
 
         public IConfiguration Configuration { get; }
@@ -32,7 +36,8 @@ namespace NVSSClient
             //services.AddDbContext<AppContext>(options => options.UseMySql(Configuration.GetConnectionString("ClientDatabase")));
             // *** SQL server ***
             //services.AddDbContext<AppContext>(options => options.UseSqlServer(Configuration.GetConnectionString("ClientDatabase")));
-            
+            services.AddOptions<AppConfig>().Bind(Configuration).ValidateDataAnnotations().ValidateOnStart();
+ 
             services.AddControllers();
         }
 
@@ -57,5 +62,28 @@ namespace NVSSClient
                 endpoints.MapControllers();
             });
         }
+
+
+        //private void ValidateKestrelSettings()
+        //{
+        //    var kestrelSettings = new KestrelSettings();
+        //    Configuration.GetSection("Kestrel").Bind(kestrelSettings);
+
+        //    var validationContext = new ValidationContext(kestrelSettings, serviceProvider: null, items: null);
+        //    var validationResults = new List<ValidationResult>();
+
+        //    if (!Validator.TryValidateObject(kestrelSettings, validationContext, validationResults, validateAllProperties: true))
+        //    {
+        //        // Log or throw exceptions for validation failures
+        //        foreach (var validationResult in validationResults)
+        //        {
+        //            Console.WriteLine($"Validation Error: {validationResult.ErrorMessage}");
+        //            // Optionally throw an exception to stop application startup
+        //            // throw new InvalidOperationException($"Configuration validation failed: {validationResult.ErrorMessage}");
+        //        }
+        //        throw new InvalidOperationException("Kestrel configuration is invalid. Please check appsettings.json.");
+        //    }
+        //    Console.WriteLine("Kestrel configuration validated successfully.");
+        //}
     }
 }

--- a/nvssclient/Startup.cs
+++ b/nvssclient/Startup.cs
@@ -3,12 +3,8 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Microsoft.OpenApi.Models;
 using NVSSClient.Models;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
+
 
 namespace NVSSClient
 {
@@ -18,7 +14,6 @@ namespace NVSSClient
         {
             Configuration = configuration;
             StaticConfig = configuration;
-  //          ValidateKestrelSettings();
         }
 
         public IConfiguration Configuration { get; }
@@ -62,28 +57,5 @@ namespace NVSSClient
                 endpoints.MapControllers();
             });
         }
-
-
-        //private void ValidateKestrelSettings()
-        //{
-        //    var kestrelSettings = new KestrelSettings();
-        //    Configuration.GetSection("Kestrel").Bind(kestrelSettings);
-
-        //    var validationContext = new ValidationContext(kestrelSettings, serviceProvider: null, items: null);
-        //    var validationResults = new List<ValidationResult>();
-
-        //    if (!Validator.TryValidateObject(kestrelSettings, validationContext, validationResults, validateAllProperties: true))
-        //    {
-        //        // Log or throw exceptions for validation failures
-        //        foreach (var validationResult in validationResults)
-        //        {
-        //            Console.WriteLine($"Validation Error: {validationResult.ErrorMessage}");
-        //            // Optionally throw an exception to stop application startup
-        //            // throw new InvalidOperationException($"Configuration validation failed: {validationResult.ErrorMessage}");
-        //        }
-        //        throw new InvalidOperationException("Kestrel configuration is invalid. Please check appsettings.json.");
-        //    }
-        //    Console.WriteLine("Kestrel configuration validated successfully.");
-        //}
     }
 }


### PR DESCRIPTION
Added validation for appsettings.json. While testing the settings data is merged from appsetting.json as well appsettings.Test.json  so presence of a field in one will not trigger the exception. 